### PR TITLE
Совместимость с IPv6

### DIFF
--- a/vk/api.py
+++ b/vk/api.py
@@ -77,7 +77,7 @@ class APISession(object):
 
         response = session.post('https://login.vk.com', login_data)
 
-        if 'remixsid' in session.cookies:
+        if 'remixsid' in session.cookies or 'remixsid6' in session.cookies:
             pass
         elif 'sid=' in response.url:
             raise VkAuthorizationError('Authorization error (captcha)')


### PR DESCRIPTION
При работе под IPv6 ВКонтакте при успешной авторизации выставляет куку "remixsid6", а не "remixsid"
