### PR TITLE
Обновление доменов VK с vk.com на vk.ru

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vk | python vk.com API wrapper
+# vk | python vk.ru API wrapper
 
 [![Maintanance](https://img.shields.io/maintenance/yes/2023?style=flat-square)](https://github.com/voronind/vk/commits/master)
 [![PyPI](https://img.shields.io/pypi/pyversions/vk?style=flat-square)](https://pypi.org/project/vk/)
@@ -6,7 +6,7 @@
 [![Codecov](https://img.shields.io/codecov/c/github/voronind/vk?style=flat-square)](https://codecov.io/gh/voronind/vk)
 [![Docs](https://img.shields.io/readthedocs/vk?style=flat-square)](https://vk.readthedocs.io/en/latest/)
 
-This is a vk.com (the largest Russian social network) python API wrapper. <br>
+This is a vk.ru (the largest Russian social network) python API wrapper. <br>
 The goal is to support all API methods (current and future) that can be accessed from server.
 
 
@@ -29,7 +29,7 @@ pip install vk
 [{'id': 1, 'first_name': 'Pavel', 'last_name': 'Durov', ... }]
 ```
 
-See official VK [documentation](https://dev.vk.com/method) for detailed API guide.
+See official VK [documentation](https://dev.vk.ru/method) for detailed API guide.
 
 
 ## More info

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Welcome to vk's documentation!
 ==============================
 
-**VK** library is a `vk.com <vk.com>`__ (the largest Russian social network) python API wrapper
+**VK** library is a `vk.ru <vk.ru>`__ (the largest Russian social network) python API wrapper
 
 Contents:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,7 +17,7 @@ Several types of APIs are implemented in this module. Each of them is needed for
 It gets user info with **user id** equal to **1**. :class:`vk.api.APINamespace` object is used to create API request and send it via original :class:`vk.session.API` class object (or another), which in turn, manages access token, sends API request, gets JSON response, parses and returns it.
 
 | More formally, this forms the following POST request to the VK API:
-| https://api.vk.com/method/users.get?user_ids=1&access_token=...&v=5.131
+| https://api.vk.ru/method/users.get?user_ids=1&access_token=...&v=5.131
 
 
 vk.API

--- a/docs/vk-api.rst
+++ b/docs/vk-api.rst
@@ -1,13 +1,13 @@
-vk.com API
+vk.ru API
 ==========
 
 
 .. _`Getting access`:
 
-Getting access (`depricated <https://github.com/vkhost/vkhost.github.io/issues/4>`__)
+Getting access
 --------------
 
-To use `vk.com <vk.com>`__ API you need an access token. There are several types of tokens, and the `official documentation <https://dev.vk.com/api/access-token/getting-started>`__ describes the process of obtaining each of them well. Based on our experience, we can offer you the fastest way to get a token - from the official application
+To use `vk.ru <vk.ru>`__ API you need an access token. There are several types of tokens, and the `official documentation <https://dev.vk.ru/api/access-token/getting-started>`__ describes the process of obtaining each of them well. Based on our experience, we can offer you the fastest way to get a token - from the official application
 
 Steps:
 
@@ -26,4 +26,4 @@ Cons:
 Making API request
 ------------------
 
-To make request to vk.com API we need send GET or POST HTTP request to address https://api.vk.com/method/METHOD with parameters of specific method, access token, version and other parameters (see `official documentation <https://dev.vk.com/api/api-requests>`__ for more details). This module is needed in order to protect you from raw HTTP requests and provide a convenient interface for making requests.
+To make request to vk.ru API we need send GET or POST HTTP request to address https://api.vk.ru/method/METHOD with parameters of specific method, access token, version and other parameters (see `official documentation <https://dev.vk.ru/api/api-requests>`__ for more details). This module is needed in order to protect you from raw HTTP requests and provide a convenient interface for making requests.

--- a/docs/vk-api.rst
+++ b/docs/vk-api.rst
@@ -4,7 +4,7 @@ vk.com API
 
 .. _`Getting access`:
 
-Getting access
+Getting access (`depricated <https://github.com/vkhost/vkhost.github.io/issues/4>`__)
 --------------
 
 To use `vk.com <vk.com>`__ API you need an access token. There are several types of tokens, and the `official documentation <https://dev.vk.com/api/access-token/getting-started>`__ describes the process of obtaining each of them well. Based on our experience, we can offer you the fastest way to get a token - from the official application

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vk"
-description = "Python vk.com API wrapper"
+description = "Python vk.ru API wrapper"
 license = { text = "MIT" }
 authors = [
     { name = "Dmitry Voronin", email = "dimka665@gmail.com" }
@@ -20,7 +20,7 @@ urls.Homepage = "https://github.com/voronind/vk"
 urls.Source = "https://github.com/voronind/vk"
 urls.Tracker = "https://github.com/voronind/vk/issues"
 readme = "README.md"
-keywords = ["vk.com", "api", "vk", "wrappper"]
+keywords = ["vk.ru", "api", "vk", "wrappper"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",

--- a/src/vk/exceptions.py
+++ b/src/vk/exceptions.py
@@ -3,7 +3,7 @@ from enum import IntEnum
 
 class ErrorCodes(IntEnum):
     """Enumeration object of VK API error codes. See `official documentation
-    <https://dev.vk.com/reference/errors>`__ for more details
+    <https://dev.vk.ru/reference/errors>`__ for more details
     """
 
     AUTHORIZATION_FAILED = 5    #: Invalid access token

--- a/src/vk/session.py
+++ b/src/vk/session.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 class APIBase:
     METHOD_COMMON_PARAMS = {'v', 'lang', 'https', 'test_mode'}
 
-    API_URL = 'https://api.vk.com/method/'
+    API_URL = 'https://api.vk.ru/method/'
 
     def __new__(cls, *args, **kwargs):
         method_common_params = {
@@ -100,7 +100,7 @@ class APIBase:
 
 
 class API(APIBase):
-    """The simplest VK API implementation. Can process `any API method <https://dev.vk.com/method>`__
+    """The simplest VK API implementation. Can process `any API method <https://dev.vk.ru/method>`__
     that can be called from the server
 
     Args:
@@ -151,12 +151,12 @@ class API(APIBase):
 class UserAPI(API):
     """Subclass of :class:`vk.session.API`. It differs only in that it can get access token
     using user credentials (`Implicit flow authorization
-    <https://dev.vk.com/api/access-token/implicit-flow-user>`__).
+    <https://dev.vk.ru/api/access-token/implicit-flow-user>`__).
 
     Warning:
         This implementation uses the web version of VK to log in and receive cookies, and then
         obtains an access token through Implicit flow authorization. In the future, VK may change
-        the approach to authorization (for example, replace it with `VK ID <https://id.vk.com>`__)
+        the approach to authorization (for example, replace it with `VK ID <https://id.vk.ru>`__)
         and maintaining operability will become quite a difficult task, and most likely it will
         be **deprecated**. Use :class:`vk.session.DirectUserAPI` instead
 
@@ -167,7 +167,7 @@ class UserAPI(API):
             "VK Admin" app ID
         scope (Optional[Union[str, int]]): Access rights you need. Can be passed
             comma-separated list of scopes, or bitmask sum all of them (see `official
-            documentation <https://dev.vk.com/reference/access-rights>`__). Defaults
+            documentation <https://dev.vk.ru/reference/access-rights>`__). Defaults
             to 'offline'
         **kwargs (any): Additional parameters, which will be passed to each request.
             The most useful is `v` - API version and `lang` - language of responses
@@ -186,8 +186,8 @@ class UserAPI(API):
             >>> print(api.users.get(user_ids=1))
             [{'id': 1, 'first_name': 'Павел', 'last_name': 'Дуров', ... }]
     """
-    LOGIN_URL = 'https://oauth.vk.com'
-    AUTHORIZE_URL = 'https://oauth.vk.com/authorize'
+    LOGIN_URL = 'https://oauth.vk.ru'
+    AUTHORIZE_URL = 'https://oauth.vk.ru/authorize'
 
     def __init__(self, user_login=None, user_password=None, client_id=6121396, scope='offline', **kwargs):
         self.user_login = user_login
@@ -213,7 +213,7 @@ class UserAPI(API):
 
     @staticmethod
     def _get_captcha_src(response):
-        captcha_src = search(r'<img[^>]* src="(https://(m|api).vk.com/captcha.php[^\"]+)"', response.text)
+        captcha_src = search(r'<img[^>]* src="(https://(m|api).vk.ru/captcha.php[^\"]+)"', response.text)
         if captcha_src:
             return captcha_src.group(1)
         raise VkAuthError(f'No CAPTCHA on page {response.url}')
@@ -235,7 +235,7 @@ class UserAPI(API):
 
     def get_access_token(self):
         auth_session = requests.Session()
-        auth_session.headers['Origin'] = 'https://oauth.vk.com'
+        auth_session.headers['Origin'] = 'https://oauth.vk.ru'
 
         if self.login(auth_session):
             return self.authorize(auth_session)
@@ -381,7 +381,7 @@ class UserAPI(API):
 
 class DirectUserAPI(UserAPI):
     """Subclass of :class:`vk.session.UserAPI`. Can get access token using user
-    credentials (through `Direct authorization <https://dev.vk.com/api/direct-auth>`__).
+    credentials (through `Direct authorization <https://dev.vk.ru/api/direct-auth>`__).
 
     See also:
         `Necessary data <https://gist.github.com/YariKartoshe4ka/02a0f2f49efdac06c423eca5661cfc36>`__
@@ -395,7 +395,7 @@ class DirectUserAPI(UserAPI):
             secret of *"VK for Android"* app
         scope (Optional[Union[str, int]]): Access rights you need. Can be passed
             comma-separated list of scopes, or bitmask sum all of them (see `official
-            documentation <https://dev.vk.com/reference/access-rights>`__). Defaults
+            documentation <https://dev.vk.ru/reference/access-rights>`__). Defaults
             to 'offline'
         **kwargs (any): Additional parameters, which will be passed to each request.
             The most useful is `v` - API version and `lang` - language of responses
@@ -414,8 +414,8 @@ class DirectUserAPI(UserAPI):
             >>> print(api.users.get(user_ids=1))
             [{'id': 1, 'first_name': 'Павел', 'last_name': 'Дуров', ... }]
     """
-    LOGIN_URL = 'https://m.vk.com'
-    AUTHORIZE_URL = 'https://oauth.vk.com/token'
+    LOGIN_URL = 'https://m.vk.ru'
+    AUTHORIZE_URL = 'https://oauth.vk.ru/token'
 
     def __init__(
         self,
@@ -528,7 +528,7 @@ class DirectUserAPI(UserAPI):
 class CommunityAPI(UserAPI):
     """Subclass of :class:`vk.session.UserAPI`. Can get community access token using user
     credentials (`Implicit flow authorization for communities
-    <https://dev.vk.com/api/access-token/implicit-flow-community>`__). To select a community
+    <https://dev.vk.ru/api/access-token/implicit-flow-community>`__). To select a community
     on behalf of which to make request to the API method, you can pass the **group_id** param
     (defaults to the first community from the passed list)
 
@@ -536,7 +536,7 @@ class CommunityAPI(UserAPI):
         This implementation uses the web version of VK to log in and receive cookies, and then
         obtains an access tokens through Implicit flow authorization for communities. In the
         future, VK may change the approach to authorization (for example, replace it with `VK ID
-        <https://id.vk.com>`__) and maintaining operability will become quite a difficult task,
+        <https://id.vk.ru>`__) and maintaining operability will become quite a difficult task,
         and most likely it will be **deprecated**.
 
         You can create a group token on the management page: Community -> Management -> Working with
@@ -550,7 +550,7 @@ class CommunityAPI(UserAPI):
             "VK Admin" app ID
         scope (Optional[Union[str, int]]): Access rights you need. Can be passed
             comma-separated list of scopes, or bitmask sum all of them (see `official
-            documentation <https://dev.vk.com/reference/access-rights>`__). Defaults
+            documentation <https://dev.vk.ru/reference/access-rights>`__). Defaults
             to ``None``. **Be careful**, only *manage*, *messages*, *photos*, *docs*,
             *wall* and *stories* are available for communities
         **kwargs (any): Additional parameters, which will be passed to each request.


### PR DESCRIPTION
## Обновление доменов VK с `vk.com` на `vk.ru`

Этот PR вносит необходимые изменения для перехода с домена `vk.com` на `vk.ru` во всех интеграциях с API ВКонтакте, в соответствии с официальным уведомлением от VK.

### Что изменилось

VK уведомил разработчиков о полном переходе на домен **`vk.ru`** для всех API-интеграций и авторизаций. Начиная с **1 октября 2025 года**, обращение к API через старые домены (`vk.com`, `api.vk.com`, `oauth.vk.com`) может прекратить работу.

### Источники
-   [Официальное уведомление о переходе на vk.ru](https://habr.com/ru/news/943232/) 
-   [История изменений VK ID SDK](https://id.vk.com/about/business/go/docs/ru/vkid/latest/vk-id/release-notes#261-10-09-2025) 